### PR TITLE
Fix floating point error in getPropFinished

### DIFF
--- a/src/mv2h/tools/midi/TimeTrackerNode.java
+++ b/src/mv2h/tools/midi/TimeTrackerNode.java
@@ -241,7 +241,7 @@ public class TimeTrackerNode {
 		}
 		
 		// Length of remainder time in sub beats
-		propFinished = ((time - currentTime) % millisPerSubBeat) / millisPerSubBeat;
+		propFinished = 1 - ((currentTime - time) % millisPerSubBeat) / millisPerSubBeat;
 		return propFinished == 0 ? 1.0 : propFinished;
 	}
 }

--- a/src/mv2h/tools/midi/TimeTrackerNode.java
+++ b/src/mv2h/tools/midi/TimeTrackerNode.java
@@ -234,10 +234,14 @@ public class TimeTrackerNode {
 		double millisPerSubBeat = getMillisPerSubBeat();
 		
 		// Correct start time for propFinished
-		double prevTime = startTime - millisPerSubBeat * propFinished;
+		double currentTime = startTime - millisPerSubBeat * propFinished + millisPerSubBeat;
+		
+		while (currentTime <= time) {
+			currentTime += millisPerSubBeat;
+		}
 		
 		// Length of remainder time in sub beats
-		propFinished = ((time - prevTime) % millisPerSubBeat) / millisPerSubBeat;
+		propFinished = ((time - currentTime) % millisPerSubBeat) / millisPerSubBeat;
 		return propFinished == 0 ? 1.0 : propFinished;
 	}
 }


### PR DESCRIPTION
The getPropFinished method is always called after getSubBeatsUntil, which incrementally updates a time value by `millisPerSubBeat`. 
This can cause errors in the generation of Tatums when subbeats are very close to (but not exactly) on a tempo change.
It's fixable by exactly imitating the behaviour of getSubBeatsUntil in getPropFinished.
I noticed this on the A-MAPS dataset (e.g., MAPS_MUS-alb_se2_ENSTDkCl.mid).
Here is a plot to illustrate the issue:

![output](https://user-images.githubusercontent.com/35711942/233846060-e6e44928-a16b-4f47-bc81-14b90a78a85e.png)

As you can see, the old algorithm would occasionally skip over a Tatum, yielding an interval spike of 2 millisPerSubBeat.
While the new algorithm is slightly slower, in practice I have not observed a difference. 